### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Ci.yml
+++ b/.github/workflows/Ci.yml
@@ -1,5 +1,7 @@
 # .github/workflows/ci.yml
 name: CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Safe-app-eth/SafeVault-/security/code-scanning/27](https://github.com/Safe-app-eth/SafeVault-/security/code-scanning/27)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the GITHUB_TOKEN. Since the workflow only checks out code, sets up Node, installs dependencies, and builds (no deployment, no PR/issue manipulation, etc.), it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow, just after the `name` and before `on`. This will apply the least privilege principle to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
