### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -1,4 +1,6 @@
 name: PR Template Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Safe-app-eth/SafeVault-/security/code-scanning/29](https://github.com/Safe-app-eth/SafeVault-/security/code-scanning/29)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the job only reads the PR body and does not need to write to the repository or perform other privileged actions, the minimal required permission is `contents: read`. This can be set at the workflow level (top-level, after the `name` and before `on:`) or at the job level (inside the `check-pr-template` job). The best practice is to set it at the workflow level so all jobs inherit the least privilege unless they need more. Edit `.github/workflows/template-check.yml` to add:

```yaml
permissions:
  contents: read
```

immediately after the `name:` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
